### PR TITLE
add Unity-specific FBX export settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@
 bl_info = {
     "name": "Super Duper Batch Exporter",
     "author": "Bastian L Strube, forked from Mrtripie",
+    "version": (2, 6, 0),
     "blender": (4, 2, 0),
     "category": "Import-Export",
     "location": "Set in preferences below. Default: Top Bar (After File, Edit, ...Help)",

--- a/operators.py
+++ b/operators.py
@@ -395,6 +395,17 @@ class EXPORT_MESH_OT_batch(Operator):
             options["filepath"] = fp+extension
             options["use_selection"] = True
             options["use_mesh_modifiers"] = settings.apply_mods
+            
+            # Unity-specific FBX export settings
+            if settings.unity_export:
+                options["global_scale"] = 1.0
+                options["apply_unit_scale"] = False
+                options["apply_scale_options"] = 'FBX_SCALE_UNITS'
+                options["use_space_transform"] = True
+                options["axis_forward"] = '-Z'
+                options["axis_up"] = 'Y'
+                options["bake_space_transform"] = True
+            
             bpy.ops.export_scene.fbx(**options)
 
             # LOD De-Creation

--- a/panels.py
+++ b/panels.py
@@ -88,6 +88,11 @@ def draw_settings(self, context):
     elif settings.file_format == 'FBX':
         col.prop(settings, 'fbx_preset_enum')
         self.layout.prop(settings, 'apply_mods')
+        
+        # Unity Compatibility
+        box = self.layout.box()
+        box.label(text="Unity Compatibility", icon="LINK_BLEND")
+        box.prop(settings, 'unity_export')
     elif settings.file_format == 'glTF':
         col.prop(settings, 'gltf_preset_enum')
         self.layout.prop(settings, 'apply_mods')

--- a/properties.py
+++ b/properties.py
@@ -165,6 +165,11 @@ class BatchExportSettings(PropertyGroup):
         description="Should the modifiers by applied onto the exported mesh?\nCan't export Shape Keys with this on",
         default=True,
     )
+    unity_export: BoolProperty(
+        name="Unity Compatible",
+        description="Export with Unity-compatible settings (scale 1:1, Y-up axis)",
+        default=True,
+    )
     frame_start: IntProperty(
         name="Frame Start",
         min=0,


### PR DESCRIPTION
pls add this fix.
- add # Unity Compatibility box
- Export with Unity-compatible settings (scale 1:1, Y-up axis)