### PR TITLE
[Feature] add mode to export with collectionname as subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ One click export to multiple files. Options are set once and stored with blend f
 ### Export Options
 Use existing export presets, set options like **Output Directory**, **Prefix**, **Suffix**, filter by **Type** or set object **Location**, **Rotation** or **Scale** on export. 
 
+In object-based modes, collection naming supports:
+- **Prefix Collection Name**: add collection name to the exported filename.
+- **Use Collection as Subfolder**: export into a collection-named subfolder.
+- These options can be enabled independently or together.
+
 **Mode** exports a file for each:
 - **Object**
 - **Parent Object**

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@
 bl_info = {
     "name": "Super Duper Batch Exporter",
     "author": "Bastian L Strube, forked from Mrtripie",
+    "version": (2, 7, 2),
     "blender": (4, 2, 0),
     "category": "Import-Export",
     "location": "Set in preferences below. Default: Top Bar (After File, Edit, ...Help)",

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "SuperDuperBatchExporter"
-version = "2.7.1"
+version = "2.7.2"
 name = "Super Duper Batch Exporter"
 tagline = "One click export to multiple files"
 maintainer = "Bastian L Strube <mail@bastianlstrube.dk>"

--- a/operators.py
+++ b/operators.py
@@ -271,6 +271,24 @@ class EXPORT_MESH_OT_batch(Operator):
 
     def export_selection(self, itemname, context, base_dir):
         settings = context.scene.batch_export
+        selected_objects = context.selected_objects
+
+        collection_name = None
+        if 'OBJECT' in settings.mode and selected_objects:
+            collection_name = selected_objects[0].users_collection[0].name
+
+            if collection_name != 'Scene Collection':
+                if settings.collection_as_subfolder:
+                    base_dir = os.path.join(base_dir, collection_name)
+                    if not os.path.exists(base_dir):
+                        try:
+                            os.makedirs(base_dir)
+                            print(f"Directory created: {base_dir}")
+                        except OSError as e:
+                            self.report({'ERROR'}, f"Error creating directory {base_dir}: {e}")
+                if settings.prefix_collection:
+                    itemname = "_".join([collection_name, itemname])
+
         # save the transform to be reset later:
         old_locations = []
         old_rotations = []
@@ -297,12 +315,6 @@ class EXPORT_MESH_OT_batch(Operator):
                     obj.rotation_euler = settings.rotation
                 if settings.set_scale:
                     obj.scale = settings.scale
-
-            # Change Itemname If Collection As Prefix
-            if settings.prefix_collection and 'OBJECT' in settings.mode:
-                collection_name = obj.users_collection[0].name
-                if not collection_name == 'Scene Collection':
-                    itemname = "_".join([collection_name, itemname])
 
             # LOD Creation
             if settings.create_lod and settings.file_format == 'FBX' and obj.type == 'MESH':

--- a/panels.py
+++ b/panels.py
@@ -60,6 +60,7 @@ def draw_settings(self, context):
     col.prop(settings, 'limit')
     if 'OBJECT' in settings.mode:
         col.prop(settings, 'prefix_collection')
+        col.prop(settings, 'collection_as_subfolder')
     if 'SUBDIR' in settings.mode:
         col.prop(settings, 'full_hierarchy')
     self.layout.separator()

--- a/properties.py
+++ b/properties.py
@@ -125,7 +125,7 @@ class BatchExportSettings(PropertyGroup):
     )
     collection_as_subfolder: BoolProperty(
         name="Use Collection as Subfolder",
-        description="Uses the containing collection name as a subfolder in the export directory (can be combined with Prefix Collection Name)"
+        description="Uses the containing collection name as a subfolder in the export directory"
     )
     full_hierarchy: BoolProperty(
         name="Full Hierarchy",

--- a/properties.py
+++ b/properties.py
@@ -123,6 +123,10 @@ class BatchExportSettings(PropertyGroup):
         name="Prefix Collection Name",
         description="Adds the containing collection's name to the exported file's name, after the 'prefix'"
     )
+    collection_as_subfolder: BoolProperty(
+        name="Use Collection as Subfolder",
+        description="Uses the containing collection name as a subfolder in the export directory (can be combined with Prefix Collection Name)"
+    )
     full_hierarchy: BoolProperty(
         name="Full Hierarchy",
         description="Create Sub-Directories for the Collection and Parent Collections,\nrecreating the hierarchy"


### PR DESCRIPTION
With this PR I added the option to create subfolders with the collection name.

This is very useful for large projects with many files, where you still want to keep some structure.

Feel free to let me know if anything is missing, not really used to work on Blender addons.