### PR TITLE
Add Unity Transform Fix for FBX export

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -431,6 +431,9 @@ class EXPORT_MESH_OT_batch(Operator):
             options["filepath"] = fp+extension
             options["use_selection"] = True
             options["use_mesh_modifiers"] = settings.apply_mods
+            if settings.fbx_unity_transform:
+                options["apply_scale_options"] = 'FBX_SCALE_ALL'
+                options["bake_space_transform"] = True
             bpy.ops.export_scene.fbx(**options)
 
             # LOD De-Creation
@@ -1003,6 +1006,9 @@ class EXPORT_MESH_OT_batch(Operator):
             "use_selection": True,
             "use_mesh_modifiers": settings.apply_mods
         })
+        if settings.fbx_unity_transform:
+            options["apply_scale_options"] = 'FBX_SCALE_ALL'
+            options["bake_space_transform"] = True
         bpy.ops.export_scene.fbx(**options)
         return full_path
     

--- a/panels.py
+++ b/panels.py
@@ -88,6 +88,7 @@ def draw_settings(self, context):
         self.layout.prop(settings, 'apply_mods')
     elif settings.file_format == 'FBX':
         col.prop(settings, 'fbx_preset_enum')
+        col.prop(settings, 'fbx_unity_transform')
         self.layout.prop(settings, 'apply_mods')
     elif settings.file_format == 'glTF':
         col.prop(settings, 'gltf_preset_enum')

--- a/properties.py
+++ b/properties.py
@@ -183,6 +183,11 @@ class BatchExportSettings(PropertyGroup):
         set=lambda self, value: setattr(
             self, 'obj_preset', preset_enum_items_refs['wm.obj_export'][value][0]),
     )
+    fbx_unity_transform: BoolProperty(
+        name="Unity Transform Fix",
+        description="Bake axis conversion and apply scale so objects import into Unity with rotation (0,0,0) and scale (1,1,1).\nSets apply_scale_options to FBX_SCALE_ALL and bake_space_transform to True",
+        default=False,
+    )
     fbx_preset: StringProperty(default='NO_PRESET')
     fbx_preset_enum: EnumProperty(
         name="Preset", options={'SKIP_SAVE'},


### PR DESCRIPTION
## Summary
- Adds a "Unity Transform Fix" checkbox in the FBX settings panel
- When enabled, overrides `apply_scale_options` to `FBX_SCALE_ALL` and `bake_space_transform` to `True`
- Fixes FBX files importing into Unity with -90° X rotation and scale 100 instead of clean (0,0,0) rotation and (1,1,1) scale

## Test plan
- [ ] Enable FBX format and check the "Unity Transform Fix" toggle
- [ ] Export a mesh and import into Unity — verify rotation is (0,0,0) and scale is (1,1,1)
- [ ] Verify exports still work correctly with the toggle disabled
- [ ] Verify the toggle works both with and without a preset selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)